### PR TITLE
Replace E2E testing with quality checks workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,4 +1,4 @@
-name: E2E Tests
+name: Quality Checks
 
 on:
   push:
@@ -7,8 +7,8 @@ on:
     branches: [ main, develop ]
 
 jobs:
-  test:
-    timeout-minutes: 15
+  quality:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     
     steps:
@@ -18,35 +18,24 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '18'
-        cache: 'npm'
+        cache: 'pnpm'
+    
+    - name: Install pnpm
+      uses: pnpm/action-setup@v2
+      with:
+        version: 8
     
     - name: Install dependencies
-      run: npm ci
+      run: pnpm install --frozen-lockfile
     
-    - name: Install Playwright Browsers
-      run: npx playwright install --with-deps
+    - name: Run ESLint
+      run: pnpm run lint
+    
+    - name: Run TypeScript type checking
+      run: pnpm run type-check
+    
+    - name: Run unit tests
+      run: pnpm run test
     
     - name: Build application
-      run: npm run build
-    
-    - name: Run E2E tests
-      run: npm run test:e2e
-      env:
-        NODE_ENV: test
-        NEXT_PUBLIC_USE_MOCK_DATA: true
-    
-    - name: Upload Playwright report
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: playwright-report
-        path: playwright-report/
-        retention-days: 30
-        
-    - name: Upload test results
-      uses: actions/upload-artifact@v4
-      if: always()
-      with:
-        name: test-results
-        path: testing/e2e/test-results/
-        retention-days: 30
+      run: pnpm run build


### PR DESCRIPTION
## Summary
- Replace Playwright E2E tests with comprehensive quality checks in GitHub Actions
- Switch from npm to pnpm for proper dependency management  
- Reorder workflow to run unit tests before build for early issue detection
- Reduce timeout from 15 to 10 minutes for faster CI feedback

## Changes Made
- **Workflow name**: Changed from "E2E Tests" to "Quality Checks"
- **Package manager**: Updated to use pnpm with proper lockfile handling
- **Test order**: Unit tests now run before build step
- **Quality checks**: ESLint → TypeScript checking → Unit tests → Build
- **Removed**: Playwright browser installation and E2E test execution
- **Timeout**: Reduced from 15 to 10 minutes

## Test Plan
- [x] Verify workflow YAML syntax is valid
- [ ] Confirm workflow runs successfully on push/PR
- [ ] Validate all quality checks execute in correct order
- [ ] Ensure pnpm commands work properly in CI environment